### PR TITLE
Upgrade to v1.0.2

### DIFF
--- a/CodeOwnersParser.sln
+++ b/CodeOwnersParser.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31402.337
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeOwnersParser", "CodeOwnersParser\CodeOwnersParser.csproj", "{0498B1C2-6A6F-44CA-A484-82158D812FFA}"
 EndProject

--- a/CodeOwnersParser/CodeOwnersParser.csproj
+++ b/CodeOwnersParser/CodeOwnersParser.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <AssemblyName>CodeOwnersParser</AssemblyName>
     <RootNamespace>CodeOwnersParser</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
-    <PackageReference Include="Octokit" Version="0.50.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
+    <PackageReference Include="Octokit" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/CodeOwnersParser/CodeOwnersParser.csproj
+++ b/CodeOwnersParser/CodeOwnersParser.csproj
@@ -6,7 +6,7 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <AssemblyName>CodeOwnersParser</AssemblyName>
     <RootNamespace>CodeOwnersParser</RootNamespace>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CodeOwnersParser/CodeOwnersParser.csproj
+++ b/CodeOwnersParser/CodeOwnersParser.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="Octokit" Version="2.0.1" />
+    <PackageReference Include="Octokit" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/CodeOwnersParser/CodeOwnersParser.csproj
+++ b/CodeOwnersParser/CodeOwnersParser.csproj
@@ -6,6 +6,7 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <AssemblyName>CodeOwnersParser</AssemblyName>
     <RootNamespace>CodeOwnersParser</RootNamespace>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CodeOwnersParser/Helpers.cs
+++ b/CodeOwnersParser/Helpers.cs
@@ -101,10 +101,6 @@ namespace CodeOwnersParser
             string regexString = "";
             //String containing the prepared path (escapeing, replacing etc.). Used so path doesn't get modified because its used as key
             string preparedPath;
-            //Entry ends with / aka only mathches folders not files
-            bool folderOnly = false;
-            //No slash at the beginning or middle, can match at any depth
-            bool anyDepth = false;
             //No slashes at all, match any file at any level
             bool fileMode = false;
 
@@ -114,10 +110,6 @@ namespace CodeOwnersParser
                 return regexString;
             }
 
-            if (path.EndsWith("/"))
-                folderOnly = true;
-            if (path[0..(path.Length - 1)].Contains("/"))
-                anyDepth = true;
             if (!path.Contains("/"))
                 fileMode = true;
 

--- a/CodeOwnersParser/Program.cs
+++ b/CodeOwnersParser/Program.cs
@@ -19,7 +19,7 @@ parser.WithParsed(options => NotifyOwners(options));
 
 static void NotifyOwners(ActionInputs inputs)
 {
-
+    Console.WriteLine($"CodeOwnersParser Version {System.Reflection.Assembly.GetEntryAssembly().GetName().Version}");
     Console.WriteLine($"Parsing codeowner file at: {inputs.WorkspaceDirectory}{inputs.file}");
     Dictionary<string, List<string>> codeowners = Helpers.ParseCodeownersFile(inputs.WorkspaceDirectory + inputs.file);
 

--- a/CodeOwnersParser/Program.cs
+++ b/CodeOwnersParser/Program.cs
@@ -36,7 +36,11 @@ static void NotifyOwners(ActionInputs inputs)
     }
 
     Console.WriteLine($"Getting PR files for PR with ID {inputs.pullID}");
-    var modifiedFilesTask = ghclient.PullRequest.Files(inputs.Owner, inputs.Name, inputs.pullID);
+    var batchPagination = new ApiOptions
+    {
+        PageSize = 100
+    };
+    var modifiedFilesTask = ghclient.PullRequest.Files(inputs.Owner, inputs.Name, inputs.pullID, batchPagination);
     List<Octokit.PullRequestFile> modifiedFiles;
     if (modifiedFilesTask.Wait(inputs.timeout))
     {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image as the .NET 5.0 SDK (this includes the runtime)
-FROM mcr.microsoft.com/dotnet/sdk:5.0 as build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 as build-env
 
 # Copy everything and publish the release (publish implicitly restores and builds)
 COPY . ./
@@ -20,6 +20,6 @@ LABEL com.github.actions.icon="bell"
 LABEL com.github.actions.color="white"
 
 # Relayer the .NET SDK, anew with the build output
-FROM mcr.microsoft.com/dotnet/runtime:5.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0
 COPY --from=build-env /out .
 ENTRYPOINT ["dotnet", "/CodeOwnersParser.dll"]


### PR DESCRIPTION
Bumps Octokit to 3.0.0 which now allows passing APIOptions to PullRequest.Files.
This allows querying 100 files per page which should decrease API usage but to 3x for very large PRs.
Upgrade to NET6 + bumps other dependencies

Also removes some unused vars that where never needed for Regex generation.